### PR TITLE
Update to net10

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project>
   <!-- These properties will be shared for all projects -->
   <PropertyGroup>
-    <VersionPrefix>3.908.0</VersionPrefix>
+    <VersionPrefix>3.1000.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
   </PropertyGroup>

--- a/src/VirtoCommerce.FileExperienceApi.Core/VirtoCommerce.FileExperienceApi.Core.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Core/VirtoCommerce.FileExperienceApi.Core.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="[8.0.11,9)" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.919.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1000.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
@@ -9,8 +9,8 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.929.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.919.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1000.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.FileExperienceApi.Core\VirtoCommerce.FileExperienceApi.Core.csproj" />

--- a/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.814.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1000.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.FileExperienceApi.Web/VirtoCommerce.FileExperienceApi.Web.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Web/VirtoCommerce.FileExperienceApi.Web.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <OutputType>Library</OutputType>
   </PropertyGroup>
   <PropertyGroup>

--- a/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <module>
   <id>VirtoCommerce.FileExperienceApi</id>
-  <version>3.908.0</version>
+  <version>3.1000.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.919.0</platformVersion>
+  <platformVersion>3.1000.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.929.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
     <dependency id="VirtoCommerce.Assets" version="3.814.0" />
   </dependencies>
 
@@ -32,7 +32,7 @@
   <moduleType>VirtoCommerce.FileExperienceApi.Web.Module, VirtoCommerce.FileExperienceApi.Web</moduleType>
 
   <releaseNotes>First version.</releaseNotes>
-  <copyright>Copyright © 2024–2025 Virto Commerce. All rights reserved</copyright>
+  <copyright>Copyright © 2024–2026 Virto Commerce. All rights reserved</copyright>
   <tags>extension module</tags>
   <useFullTypeNameInSwagger>false</useFullTypeNameInSwagger>
 </module>

--- a/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
@@ -7,7 +7,7 @@
   <platformVersion>3.1000.0</platformVersion>
   <dependencies>
     <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Assets" version="3.814.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
   </dependencies>
 
   <title>File Experience API</title>

--- a/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
+++ b/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
+++ b/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <PropertyGroup>
@@ -12,9 +12,9 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
-    <PackageReference Include="xunit" Version="2.6.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\VirtoCommerce.FileExperienceApi.Core\VirtoCommerce.FileExperienceApi.Core.csproj" />


### PR DESCRIPTION
## Description


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Framework and dependency upgrades can introduce runtime/build compatibility issues across the module and its platform integrations, though no application logic changes are included.
> 
> **Overview**
> Upgrades the File Experience API module to target `net10.0` across core, data, web, and test projects.
> 
> Bumps the module/versioning to `3.1000.0`, aligns VirtoCommerce package dependencies (Platform/Core/Security, Xapi, Assets) to `3.1000.0`, updates `Microsoft.AspNetCore.Authorization` to `10.0.1`, and refreshes test dependencies to `Microsoft.NET.Test.Sdk` `18.0.1` + `xunit.v3`.
> 
> Updates `module.manifest` versions accordingly and extends the copyright year range.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4edea66b3331c9912f0c3044369f724b09248576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4569

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileExperienceApi_3.1000.0-pr-18-4ede.zip