### PR TITLE
VCST-5163: Stable 15 — FileExperienceApi (platform 3.1039.0)

### DIFF
--- a/src/VirtoCommerce.FileExperienceApi.Core/VirtoCommerce.FileExperienceApi.Core.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Core/VirtoCommerce.FileExperienceApi.Core.csproj
@@ -9,6 +9,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.1" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Core" Version="3.1039.0" />
   </ItemGroup>
 </Project>

--- a/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
@@ -8,9 +8,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1000.0" />
-    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1000.0" />
+    <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\VirtoCommerce.FileExperienceApi.Core\VirtoCommerce.FileExperienceApi.Core.csproj" />

--- a/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
@@ -4,10 +4,10 @@
   <version>3.1003.0</version>
   <version-tag></version-tag>
 
-  <platformVersion>3.1000.0</platformVersion>
+  <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.1000.0" />
-    <dependency id="VirtoCommerce.Assets" version="3.1000.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
   </dependencies>
 
   <title>File Experience API</title>

--- a/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
+++ b/tests/VirtoCommerce.FileExperienceApi.Tests/VirtoCommerce.FileExperienceApi.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
@@ -8,7 +8,7 @@
     <SonarQubeTestProject>true</SonarQubeTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Part of **Stable 15** (Wave 6). Builds against published platform [3.1039.0](https://github.com/VirtoCommerce/vc-platform/releases/tag/3.1039.0) + Wave 1–5 packages on nuget.org. Version handled by CI.

- Xapi dep bumped to 3.1012.0.
- `vc-build Compress` green incl. unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency and manifest version bumps only; no runtime or security logic changes in the diff.
> 
> **Overview**
> **Stable 15 alignment** for File Experience API: NuGet and module manifest versions are bumped so the module builds and declares compatibility with **Virto Commerce platform 3.1039.0** and the matching Wave packages.
> 
> **Core** references `VirtoCommerce.Platform.Core` **3.1039.0** (was 3.1000.0). **Data** updates `VirtoCommerce.Platform.Security` to **3.1039.0**, `VirtoCommerce.AssetsModule.Core` to **3.1005.0**, and `VirtoCommerce.Xapi.Core` to **3.1012.0**. **`module.manifest`** sets `platformVersion` to **3.1039.0** and dependency versions for **Xapi** (**3.1012.0**) and **Assets** (**3.1005.0**).
> 
> Tests only bump **coverlet.collector** to **10.0.1** and drop a BOM from the test project file. No application or API logic changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 797dca2300ba92adbe10fa0b026daafea144ae51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5163
Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileExperienceApi_3.1003.0-pr-20-797d.zip