### PR TITLE
VCST-5468: Resolve mediators per request

### DIFF
--- a/src/VirtoCommerce.FileExperienceApi.Data/Commands/DeleteFileCommandBuilder.cs
+++ b/src/VirtoCommerce.FileExperienceApi.Data/Commands/DeleteFileCommandBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using GraphQL;
 using GraphQL.Types;
@@ -21,14 +22,23 @@ public class DeleteFileCommandBuilder : CommandBuilder<DeleteFileCommand, bool, 
     private readonly IFileAuthorizationService _fileAuthorizationService;
 
     public DeleteFileCommandBuilder(
+        IAuthorizationService authorizationService,
+        IFileUploadService fileUploadService,
+        IFileAuthorizationService fileAuthorizationService)
+        : base(authorizationService)
+    {
+        _fileUploadService = fileUploadService;
+        _fileAuthorizationService = fileAuthorizationService;
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    public DeleteFileCommandBuilder(
         IMediator mediator,
         IAuthorizationService authorizationService,
         IFileUploadService fileUploadService,
         IFileAuthorizationService fileAuthorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService, fileUploadService, fileAuthorizationService)
     {
-        _fileUploadService = fileUploadService;
-        _fileAuthorizationService = fileAuthorizationService;
     }
 
     protected override async Task BeforeMediatorSend(IResolveFieldContext<object> context, DeleteFileCommand request)

--- a/src/VirtoCommerce.FileExperienceApi.Data/Queries/OptionsQueryBuilder.cs
+++ b/src/VirtoCommerce.FileExperienceApi.Data/Queries/OptionsQueryBuilder.cs
@@ -1,3 +1,4 @@
+using System;
 using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using VirtoCommerce.Xapi.Core.BaseQueries;
@@ -10,8 +11,14 @@ public class OptionsQueryBuilder : QueryBuilder<OptionsQuery, FileUploadScopeOpt
 {
     protected override string Name => "FileUploadOptions";
 
+    public OptionsQueryBuilder(IAuthorizationService authorizationService)
+        : base(authorizationService)
+    {
+    }
+
+    [Obsolete("Use the constructor without IMediator. The mediator is resolved from context.RequestServices per request.", DiagnosticId = "VC0015", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public OptionsQueryBuilder(IMediator mediator, IAuthorizationService authorizationService)
-        : base(mediator, authorizationService)
+        : this(authorizationService)
     {
     }
 }

--- a/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
+++ b/src/VirtoCommerce.FileExperienceApi.Data/VirtoCommerce.FileExperienceApi.Data.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <PackageReference Include="VirtoCommerce.AssetsModule.Core" Version="3.1005.0" />
-    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1012.0" />
+    <PackageReference Include="VirtoCommerce.Xapi.Core" Version="3.1015.0" />
     <PackageReference Include="VirtoCommerce.Platform.Security" Version="3.1039.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
+++ b/src/VirtoCommerce.FileExperienceApi.Web/module.manifest
@@ -6,7 +6,7 @@
 
   <platformVersion>3.1039.0</platformVersion>
   <dependencies>
-    <dependency id="VirtoCommerce.Xapi" version="3.1012.0" />
+    <dependency id="VirtoCommerce.Xapi" version="3.1015.0" />
     <dependency id="VirtoCommerce.Assets" version="3.1005.0" />
   </dependencies>
 


### PR DESCRIPTION
## Description

GraphQL command and query builders are singleton schema components. Constructor-injected `IMediator` captures the root provider and can resolve scoped handler dependencies from the wrong scope.

Upgrade XApi to `3.1015.0` and resolve mediation through `context.GetMediator()` per request. `DeleteFileCommandBuilder` and `OptionsQueryBuilder` use mediator-free constructors; obsolete compatibility overloads are retained.

## References
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

### Artifact URL:
https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.FileExperienceApi_3.1004.0-alpha.89-vcst-5468.zip
<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request-scoped mediation for GraphQL mutations/queries including delete authorization paths; low surface area but fixes a real scoped-dependency bug.
> 
> **Overview**
> **Fixes incorrect DI scope for MediatR** on singleton GraphQL builders by upgrading **VirtoCommerce.Xapi** to `3.1015.0` and stopping constructor injection of `IMediator` in `DeleteFileCommandBuilder` and `OptionsQueryBuilder`. Mediation is now resolved per request via the updated XApi base types (e.g. from request services / `GetMediator()`), so scoped handlers are not pulled from the root provider.
> 
> The primary constructors only take `IAuthorizationService` (plus file services for delete). **Obsolete** `IMediator` overloads remain (diagnostic **VC0015**) for binary compatibility. `module.manifest` bumps the **VirtoCommerce.Xapi** dependency to match the package reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d69483b71aff2f2f44661f92f5d8b243dce89bf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->